### PR TITLE
fix: disable bootJar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 plugins {
     alias(libs.plugins.jvm)
@@ -23,6 +24,10 @@ java {
 
 tasks.named<Jar>("javadocJar") {
     from(tasks.named("dokkaJavadoc"))
+}
+
+tasks.named<BootJar>("bootJar") {
+    enabled = false
 }
 
 tasks.withType<KotlinCompile> {


### PR DESCRIPTION
We now include ﻿`org.springframework.boot` in our version catalog to improve version control. However, the `bootJar` task that comes with it is not suitable for our project, as we only need to declare the Spring Boot version and make it compatible with `dependabot`. To build the module, we need to disable it.