### PR TITLE
chore: upgrade gradle action version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,11 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
+
+      - uses: gradle/actions/setup-gradle@v3
+
       - name: Build and Publish
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: build publish
+        run: ./gradlew build publish
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}


### PR DESCRIPTION
Upgraded the Gradle action version from `v2` to `v3`

Replacing `uses: gradle/gradle-build-action@v2` with `uses: gradle/actions/setup-gradle@v3` 

The `arguments` parameter will be deprecated in Gradle action `v3`, we should use the `run` command instead of the `arguments` parameter

> As of `v3` this action has been superseded by `gradle/actions/setup-gradle`.
> Any workflow that uses `gradle/gradle-build-action@v3` will transparently delegate to `gradle/actions/setup-gradle@v3`.
>
> Users are encouraged to update their workflows, replacing:
> ```
> uses: gradle/gradle-build-action@v3
> ```
>
> with
> ```
> uses: gradle/actions/setup-gradle@v3
> ```

References: 
- https://github.com/gradle/gradle-build-action, https://github.com/gradle/actions/tree/main/setup-gradle
- https://github.com/gradle/gradle-build-action/issues/996